### PR TITLE
Update release drafter permissions in workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$RESOLVED_VERSION 🌈'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION 🌈'
+tag-template: '$RESOLVED_VERSION'
 
 categories:
 - title: '🚀 Features'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,8 +9,14 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # (Optional) GitHub Enterprise requires GHE_HOST variable set


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: リリースドラフターの名前テンプレートとタグテンプレートの形式を変更し、バージョン番号の前にあった 'v' 文字を削除しました。これにより、エンドユーザーに表示されるリリースドラフトの名前とタグがより直感的になりました。
- Chore: GitHub Actionsのワークフローにおけるリリースドラフトの更新に関するパーミッションを調整しました。全体のパーミッションでcontentsを読み取り専用にし、update_release_draftジョブに対してはcontentsとpull-requestsの書き込みパーミッションを付与しました。これにより、リリースドラフトの更新プロセスのセキュリティが強化されました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->