### PR TITLE
Add commitish parameter for release-drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,9 +5,8 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
-      - develop
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -26,8 +25,8 @@ jobs:
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v6
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
+        with:
+          commitish: main
         #   config-name: my-config.yml
         #   disable-autolabeler: true
         env:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: GitHub Actionsの設定を更新しました。`pull_request`イベントのトリガーが`main`と`develop`ブランチから`opened`、`reopened`、`synchronize`タイプに変更され、`release-drafter`アクションの設定も更新されました。これにより、リリースドラフトは`main`ブランチのコミットに基づいて作成され、開発プロセスがより効率的になります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->