### PR TITLE
Update name and tag templates to include 'v' prefix

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: '$RESOLVED_VERSION 🌈'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
 
 categories:
 - title: '🚀 Features'


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: リリースドラフターの設定ファイルに`v`プレフィックスを追加しました。これにより、生成されるリリース名とタグに`v`が自動的に追加されます。この変更はユーザーインターフェースやアプリケーションの動作には影響を与えませんが、リリースのバージョン表記を一貫性を持たせるためのものです。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->