### PR TITLE
release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: '$RESOLVED_VERSION 🌈'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
 
 categories:
 - title: '🚀 Features'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: リリースドラフトのテンプレートに`v`を追加しました。これにより、新しいリリースのバージョン番号の前に`v`が自動的に付けられるようになります。この変更はユーザーに直接影響を与えるものではありませんが、リリースの一貫性と認識性を向上させます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->