### PR TITLE
Update Python version to '3.10' in workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: GitHub ActionsのPythonセットアップステップで使用するPythonのバージョン指定を改善しました。数値の3.10から文字列の'3.10'に変更しました。この変更により、ワークフローの設定がより一貫性を持ち、予期しないエラーを防ぐことができます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->