### PR TITLE
Update supervisor name attribute to role name in message creation

### DIFF
--- a/gpt_all_star/core/project.py
+++ b/gpt_all_star/core/project.py
@@ -191,7 +191,7 @@ class Project:
             yield {
                 "messages": [
                     Message.create_human_message(
-                        message=str(tasks), name=self.supervisor.name
+                        message=str(tasks), name=self.supervisor.role.name
                     )
                 ],
             }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: メッセージ作成時の名前属性をリファクタリングしました。以前はスーパーバイザーの名前(`self.supervisor.name`)を使用していましたが、今後はスーパーバイザーの役割名(`self.supervisor.role.name`)を使用します。これにより、メッセージの作成者名がより具体的になり、役割に基づいた情報が提供されます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->