### PR TITLE
Add optional display parameter to run_command method

### DIFF
--- a/gpt_all_star/core/execution/execution.py
+++ b/gpt_all_star/core/execution/execution.py
@@ -46,6 +46,7 @@ Generate an command to execute the application.
             self.copilot.state(self._("Attempt %d/%d") % (attempt + 1, MAX_ATTEMPTS))
             try:
                 self.copilot.run_command(command["command"])
+                return
             except KeyboardInterrupt:
                 break
             except Exception as e:

--- a/gpt_all_star/core/project.py
+++ b/gpt_all_star/core/project.py
@@ -192,7 +192,11 @@ Generate an command to execute the application.
         MAX_ATTEMPTS = 5
         for attempt in range(MAX_ATTEMPTS):
             try:
-                self.copilot.run_command(command["command"])
+                url = self.copilot.run_command(command["command"], display=False)
+                yield {
+                    "messages": [Message.create_human_message(message=f"URL: {url}")],
+                }
+                return
             except Exception as e:
                 yield {
                     "messages": [


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能: `run_command`メソッドに新たなパラメータ`display`が追加され、表示の有無を制御できるようになりました。
- リファクタリング: `_wait_for_server`メソッドがURLを返すように変更され、`_check_browser_errors`メソッドがURLを引数として受け取るようになりました。
- リファクタリング: プロセスの終了処理が`os.killpg`を使用するように変更され、キーボード割り込みのハンドリングも改善されました。
- 新機能: `execute`メソッド内の`run_command`メソッドの呼び出しに`display`パラメータが追加され、その結果をURLとして取得します。
- リファクタリング: `run_command`が成功した場合にはすぐにメソッドが終了するようになりました。これにより、コードの実行が効率化されました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->