### PR TITLE
Update Specification class by removing japanese_mode

### DIFF
--- a/gpt_all_star/core/steps/specification/specification.py
+++ b/gpt_all_star/core/steps/specification/specification.py
@@ -13,7 +13,6 @@ class Specification(Step):
         self.working_directory = self.copilot.storages.docs.path.absolute()
         self.instructions = ""
         self.app_type = ""
-        self.japanese_mode = japanese_mode
 
     def planning_prompt(self) -> str:
         return ""


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `Specification`クラスの初期化関数から`japanese_mode`パラメータが削除されました。これにより、ユーザーはクラスのインスタンス化時に`japanese_mode`を設定することができなくなりました。この変更は、クラスの使用方法に影響を与える可能性があります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->