### PR TITLE
Add translator creation before setting project name

### DIFF
--- a/gpt_all_star/core/project.py
+++ b/gpt_all_star/core/project.py
@@ -34,13 +34,12 @@ class Project:
         self.start_time = None
         self.plan_and_solve = plan_and_solve
         self._set_modes(japanese_mode, review_mode, debug_mode)
+        self._ = create_translator("ja" if japanese_mode else "en")
         self._set_project_name(project_name)
         self._set_storages()
         self._set_copilot()
         self._set_agents()
         self._set_step_type(step)
-
-        self._ = create_translator("ja" if japanese_mode else "en")
 
     def _set_modes(
         self, japanese_mode: bool, review_mode: bool, debug_mode: bool


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `gpt_all_star/core/project.py`の`create_translator`関数の呼び出し位置を変更しました。これにより、プロジェクト名を設定する前に翻訳機能が利用可能になり、ユーザーがよりスムーズに翻訳機能を利用できるようになりました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->