### PR TITLE
Add support for Japanese mode with important notice

### DIFF
--- a/gpt_all_star/core/gpt_all_star.py
+++ b/gpt_all_star/core/gpt_all_star.py
@@ -6,14 +6,32 @@ class GptAllStar:
     def __init__(self):
         pass
 
-    def chat(self, project_name: str, step: StepType = None, message=None):
-        respond = Respond(step=step, project_name=project_name)
+    def chat(
+        self,
+        project_name: str,
+        step: StepType = None,
+        message=None,
+        japanese_mode: bool = False,
+    ):
+        respond = Respond(
+            step=step, project_name=project_name, japanese_mode=japanese_mode
+        )
         return respond.chat(message=message)
 
-    def improve(self, project_name: str, step: StepType = None, message=None):
-        respond = Respond(step=step, project_name=project_name)
+    def improve(
+        self,
+        project_name: str,
+        step: StepType = None,
+        message=None,
+        japanese_mode: bool = False,
+    ):
+        respond = Respond(
+            step=step, project_name=project_name, japanese_mode=japanese_mode
+        )
         return respond.improve(message=message)
 
-    def execute(self, project_name: str):
-        respond = Respond(step=StepType.NONE, project_name=project_name)
+    def execute(self, project_name: str, japanese_mode: bool = False):
+        respond = Respond(
+            step=StepType.NONE, project_name=project_name, japanese_mode=japanese_mode
+        )
         return respond.execute()

--- a/gpt_all_star/core/respond.py
+++ b/gpt_all_star/core/respond.py
@@ -82,6 +82,9 @@ class Respond:
                 storages=self.storages, debug_mode=self.debug_mode
             ),
         )
+        for agent in self.agents.to_array():
+            if self.japanese_mode:
+                agent.profile += "\n**IMPORTANT: 必ず日本語で書いて下さい**"
 
     def _set_step_type(self, step: StepType) -> None:
         self.step_type = step or StepType.DEFAULT

--- a/gpt_all_star/locales/ja_JP/ja.po
+++ b/gpt_all_star/locales/ja_JP/ja.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-03-27 14:56+0900\n"
-"PO-Revision-Date: 2024-03-27 14:58+0900\n"
+"POT-Creation-Date: 2024-04-09 09:06+0900\n"
+"PO-Revision-Date: 2024-04-09 09:07+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ja_JP\n"
@@ -96,20 +96,20 @@ msgstr "リポジトリへのプッシュ中にエラーが発生しました : 
 msgid "Attempt %d/%d"
 msgstr "試行回数 %d/%d"
 
-#: core/project.py:86 core/respond.py:90
+#: core/project.py:85 core/respond.py:93
 msgid "Archiving previous results..."
 msgstr "過去の結果をアーカイブ中です…"
 
-#: core/project.py:94
+#: core/project.py:93
 msgid "Interrupt received! Stopping..."
 msgstr "割り込みを受けた！停止中です…"
 
-#: core/project.py:109
+#: core/project.py:108
 #, python-format
 msgid "Retrying step: %s (Attempt %d/%d)"
 msgstr "リトライステップ : %s (試行回数 %d/%d)"
 
-#: core/project.py:115
+#: core/project.py:114
 #, python-format
 msgid "Failed to execute step: %s. Reason: %s"
 msgstr "ステップ %s の実行に失敗しました。理由：%s"
@@ -127,13 +127,15 @@ msgstr "このアプリケーションコードをGitHubで管理したいです
 msgid "Project finished. Elapsed time: %.2f seconds."
 msgstr "プロジェクト終了 経過時間：%.2f 秒"
 
-#: core/respond.py:227
+#: core/respond.py:231
 msgid "Client-Side Web Application"
 msgstr "クライアント側ウェブアプリケーション"
 
 #: core/steps/development/development.py:35
+#: core/steps/quality_assurance/quality_assurance.py:38
 #: core/steps/specification/specification.py:56
-#: core/steps/system_design/system_design.py:31
+#: core/steps/system_design/system_design.py:33
+#: core/steps/ui_design/ui_design.py:31
 msgid "What do you want to update?"
 msgstr "どのように更新したいですか？"
 
@@ -179,40 +181,42 @@ msgstr "  ┗ 私が責任者です"
 msgid "Planning tasks."
 msgstr "タスクのプランニング"
 
-#: core/team.py:140
-#, python-format
+#: core/team.py:146
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "\n"
+#| "Task: %s\n"
+#| "Context: %s\n"
+#| "---\n"
 msgid ""
 "\n"
 "\n"
 "Task: %s\n"
 "Context: %s\n"
-"Objective: %s\n"
-"Reason: %s\n"
 "---\n"
 msgstr ""
 "\n"
 "\n"
 "タスク: %s\n"
 "背景: %s\n"
-"目的: %s\n"
-"理由: %s\n"
 "—\n"
 
-#: core/team.py:224
+#: core/team.py:232
 msgid "Loading members from `agent.yml`..."
 msgstr "`agent.yml`からメンバーをロード中…"
 
-#: core/team.py:248
+#: core/team.py:256
 #, python-format
 msgid "Please introduce the %s."
 msgstr "%sについて説明してください。"
 
-#: core/team.py:256
+#: core/team.py:264
 #, python-format
 msgid "What is the name of the %s?"
 msgstr "%sの名前は何ですか?"
 
-#: core/team.py:263
+#: core/team.py:271
 #, python-format
 msgid "What is the profile of the %s?"
 msgstr "%sのプロフィールを教えて下さい"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能: `GptAllStar`と`Respond`クラスに新たなパラメータ`japanese_mode`を追加し、日本語モードのサポートを強化しました。これにより、エージェントは日本語での対話が可能になります。
- 新機能: ロケールファイル`ja.po`を更新し、メッセージIDとメッセージ文字列を改善しました。これにより、エンドユーザーに対する日本語のメッセージがより明確になります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->