### PR TITLE
Add separate lint and test jobs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,46 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
-  ci:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-
       - name: Install Requirements
         run: |
           sudo apt-get update &&
           pip install poetry &&
           poetry lock &&
           poetry install
-
       - name: Run Ruff
         run: poetry run make code-check
         continue-on-error: true
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Requirements
+        run: |
+          sudo apt-get update &&
+          pip install poetry &&
+          poetry lock &&
+          poetry install
       - name: Test with pytest
         run: poetry run make test
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: junit/test-results.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- リファクタ: CIワークフローが改善され、lintとtestジョブが分離されました。これにより、各ジョブが独立して実行されるようになり、より効率的な開発プロセスが可能になりました。
- 新機能: テスト結果をアーティファクトとしてアップロードする新しいステップが追加されました。これにより、テスト結果の確認が容易になりました。
- リファクタ: ワークフローのトリガーがpushからpull_requestに変更されました。これにより、プルリクエストの作成時に自動的にワークフローが実行されるようになりました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->