### PR TITLE
Check member_names before returning next/assign values

### DIFF
--- a/gpt_all_star/core/agents/chain.py
+++ b/gpt_all_star/core/agents/chain.py
@@ -57,7 +57,10 @@ If the worker is prompted to finish like `Supervisor: FINISH`, always be answere
             )
 
         def parse(message: Next) -> dict:
-            return {"next": self.remove_quotes(message.next)}
+            next = self.remove_quotes(message.next)
+            if next in member_names:
+                return {"next": next}
+            return {"next": "FINISH"}
 
         return prompt | self.llm.with_structured_output(Next) | parse
 
@@ -92,7 +95,10 @@ Given the following user request, respond with the worker to act next.
             )
 
         def parse(message: Assign) -> dict:
-            return {"assign": self.remove_quotes(message.assign)}
+            assign = self.remove_quotes(message.assign)
+            if assign in member_names:
+                return {"assign": assign}
+            return {"assign": "PROJECT_MANAGER"}
 
         return prompt | self.llm.with_structured_output(Assign) | parse
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `Next`と`Assign`クラスの`parse`メソッドを改善しました。これにより、メッセージから取り出される`next`または`assign`の値が`member_names`に存在する場合にのみその値が返されます。存在しない場合、`next`は`"FINISH"`を、`assign`は`"PROJECT_MANAGER"`を返すようになりました。これにより、コードのロジックがより明確になり、エラーの可能性が減少します。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->