### PR TITLE
feat(llm): add base_url support to _create_chat_openai

### DIFF
--- a/gpt_all_star/core/llm.py
+++ b/gpt_all_star/core/llm.py
@@ -15,9 +15,11 @@ class LLM_TYPE(str, Enum):
 
 def create_llm(llm_name: LLM_TYPE) -> BaseChatModel:
     if llm_name == LLM_TYPE.OPENAI:
+        print(os.getenv("OPENAI_API_BASE_URL"))
         return _create_chat_openai(
             model_name=os.getenv("OPENAI_API_MODEL", "gpt-4o"),
             temperature=0.1,
+            base_url=os.getenv("OPENAI_API_BASE"),
         )
     elif llm_name == LLM_TYPE.AZURE:
         return _create_azure_chat_openai(
@@ -40,13 +42,16 @@ def create_llm(llm_name: LLM_TYPE) -> BaseChatModel:
         raise ValueError(f"Unsupported LLM type: {llm_name}")
 
 
-def _create_chat_openai(model_name: str, temperature: float) -> ChatOpenAI:
+def _create_chat_openai(
+    model_name: str, temperature: float, base_url: str | None
+) -> ChatOpenAI:
     openai.api_type = "openai"
     return ChatOpenAI(
         model_name=model_name,
         temperature=temperature,
         streaming=True,
         client=openai.chat.completions,
+        openai_api_base=base_url,
     )
 
 

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+import pytest
+
+from gpt_all_star.core.llm import _create_chat_openai
+
+
+@pytest.fixture
+def mock_openai():
+    with patch("gpt_all_star.core.llm.openai") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_chat_openai():
+    with patch("gpt_all_star.core.llm.ChatOpenAI") as mock:
+        yield mock
+
+
+def test_create_chat_openai_with_base_url(mock_openai, mock_chat_openai):
+    base_url = "https://custom-openai-api.com/v1"
+    _create_chat_openai(model_name="gpt-4", temperature=0.1, base_url=base_url)
+
+    mock_chat_openai.assert_called_once_with(
+        model_name="gpt-4",
+        temperature=0.1,
+        streaming=True,
+        client=mock_openai.chat.completions,
+        openai_api_base=base_url,
+    )
+
+
+def test_create_chat_openai_without_base_url(mock_openai, mock_chat_openai):
+    _create_chat_openai(model_name="gpt-4", temperature=0.1, base_url=None)
+
+    mock_chat_openai.assert_called_once_with(
+        model_name="gpt-4",
+        temperature=0.1,
+        streaming=True,
+        client=mock_openai.chat.completions,
+        openai_api_base=None,
+    )


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能: `_create_chat_openai`関数に`base_url`パラメータを追加し、OpenAIのAPIのベースURLを動的に設定できるようになりました。これにより、異なる環境でのAPIの利用が容易になります。
- テスト: `base_url`パラメータが指定された場合と指定されなかった場合の両方をテストする新しいテストケースを追加しました。これにより、新機能の安定性が確保されます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->